### PR TITLE
Make sluggifier injectable

### DIFF
--- a/src/UniqueSluggifier.php
+++ b/src/UniqueSluggifier.php
@@ -21,13 +21,14 @@ declare(strict_types=1);
 namespace TOC;
 
 use Cocur\Slugify\Slugify;
+use Cocur\Slugify\SlugifyInterface;
 
 /**
  * UniqueSluggifier creates slugs from text without repeating the same slug twice per instance
  *
  * @author Casey McLaughlin <caseyamcl@gmail.com>
  */
-class UniqueSluggifier
+class UniqueSluggifier implements SlugifyInterface
 {
     /**
      * @var Slugify
@@ -54,11 +55,12 @@ class UniqueSluggifier
      * Slugify
      *
      * @param string $text
+     * @param null $options
      * @return string
      */
-    public function slugify(string $text): string
+    public function slugify($text, $options = null): string
     {
-        $slugged = $this->slugify->slugify($text);
+        $slugged = $this->slugify->slugify($text, $options);
 
         $count = 1;
         $orig = $slugged;


### PR DESCRIPTION
## Description

If the text of heading is not english character it will get the incorrect slug.
Slugification method can vary according to the language, so just make the sluggifier injectable to solve the problem.
Plus, there is no breaking changes.

(If this PR is ok to be merged, could you merge it into v2.2 too?)