### PR TITLE
Test enhancement for assertion and class namespace

### DIFF
--- a/tests/TocGeneratorTest.php
+++ b/tests/TocGeneratorTest.php
@@ -41,7 +41,7 @@ class TocGeneratorTest extends TestCase
         $obj = new TocGenerator();
 
         $html = "<h1 id='x'>A-Header</h1><h1 id='y'>A-Header</h1>";
-        $this->assertSame(2, count($obj->getMenu($html)));
+        $this->assertCount(2, $obj->getMenu($html));
     }
 
     public function testGetMenuTraversesLevelsCorrectly(): void
@@ -118,8 +118,8 @@ class TocGeneratorTest extends TestCase
     public function testGetMenuReturnsEmptyMenuItemWhenNoContentOrMatches(): void
     {
         $obj = new TocGenerator();
-        $this->assertEquals(0, count($obj->getMenu("<h1>Boo</h1><h2>Bar</h2>")));
-        $this->assertEquals(0, count($obj->getMenu("")));
+        $this->assertCount(0, $obj->getMenu("<h1>Boo</h1><h2>Bar</h2>"));
+        $this->assertCount(0, $obj->getMenu(""));
     }
 
     public function testGetOrderedMenu(): void
@@ -141,10 +141,10 @@ class TocGeneratorTest extends TestCase
         int $expectedTopLevelItems,
         int $expectedSubItems = 0
     ): void {
-        $this->assertEquals($expectedTopLevelItems, count($menuItem->getChildren()));
+        $this->assertCount($expectedTopLevelItems, $menuItem->getChildren());
 
         if ($expectedSubItems > 0) {
-            $this->assertEquals($expectedSubItems, count($menuItem->getFirstChild()->getChildren()));
+            $this->assertCount($expectedSubItems, $menuItem->getFirstChild()->getChildren());
         }
     }
 

--- a/tests/TocTwigExtensionTest.php
+++ b/tests/TocTwigExtensionTest.php
@@ -43,9 +43,9 @@ class TocTwigExtensionTest extends TestCase
         $obj = new TocTwigExtension();
         $expected = ['add_anchors'];
 
-        $this->assertEquals(count($expected), count(array_map(function (TwigFilter $v) {
+        $this->assertCount(count($expected), array_map(function (TwigFilter $v) {
             return $v->getName();
-        }, $obj->getFilters())));
+        }, $obj->getFilters()));
     }
 
 
@@ -55,9 +55,9 @@ class TocTwigExtensionTest extends TestCase
         $obj = new TocTwigExtension();
         $expected = ['toc', 'toc_items', 'add_anchors', 'toc_ordered'];
 
-        $this->assertEquals(count($expected), count(array_map(function (TwigFunction $v) {
+        $this->assertCount(count($expected), array_map(function (TwigFunction $v) {
             return $v->getName();
-        }, $obj->getFunctions())));
+        }, $obj->getFunctions()));
     }
 
     /**

--- a/tests/UniqueSlugifyTest.php
+++ b/tests/UniqueSlugifyTest.php
@@ -1,6 +1,7 @@
 <?php
 
-use TOC\UniqueSlugify;
+namespace TOC;
+
 use PHPUnit\Framework\TestCase;
 
 class UniqueSlugifyTest extends TestCase


### PR DESCRIPTION
## Description
- test improvements.

## Changed log

- Using the `assertCount` to assert expected is same as result count.
- Adding the `TOC` namespace for `tests/UniqueSlugifyTest.php` class.