### PR TITLE
Fixed MarkupFixer id format

### DIFF
--- a/src/MarkupFixer.php
+++ b/src/MarkupFixer.php
@@ -84,7 +84,11 @@ class MarkupFixer
                 continue;
             }
 
-            $node->setAttribute('id', $slugger->slugify($node->getAttribute('title') ?: $node->textContent));
+            $id = $slugger->slugify($node->getAttribute('title') ?: $node->textContent);
+            if (ctype_digit(substr($id, 0, 1))) {
+                $id = 'toc-' . $id;
+            }
+            $node->setAttribute('id', $id);
         }
 
         return $this->htmlParser->saveHTML(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If the ID given with MarkupFixer starts with a number, it adds a prefix.

## Motivation and context

IDs cannot start with numbers. Tags whose content starts with a number are not clickable.

## How has this been tested?

There is no test for clickability.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [ ] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. I'm here to help!
